### PR TITLE
Reset `nginx_static_dir` default value to `public`

### DIFF
--- a/lib/capistrano/nginx.rb
+++ b/lib/capistrano/nginx.rb
@@ -7,7 +7,7 @@ module Capistrano
       set :nginx_sudo_tasks,          -> { ['nginx:start', 'nginx:stop', 'nginx:restart', 'nginx:reload', 'nginx:configtest', 'nginx:site:add', 'nginx:site:disable', 'nginx:site:enable', 'nginx:site:remove' ] }
       set :nginx_log_path,            -> { "#{shared_path}/log" }
       set :nginx_service_path,        -> { 'service nginx' }
-      set :nginx_static_dir,          -> { "#{shared_path}/public/assets" }
+      set :nginx_static_dir,          -> { "public" }
       set :nginx_application_name,    -> { fetch(:application) }
       set :nginx_sites_enabled_dir,   -> { "/etc/nginx/sites-enabled" }
       set :nginx_sites_available_dir, -> { "/etc/nginx/sites-available" }


### PR DESCRIPTION
During the [Add sudo prompt, convert to cap plugin](https://github.com/treenewbee/capistrano3-nginx/commit/267e20d80d9f362cba9ab2e261682ad76720102c) commit the default value of `nginx_static_dir` was changed from `public` to `#{shared_path}/public/assets`.

This means when deploying the Nginx template the root is set to something like `/var/www/apps/site/current//var/www/apps/site/shared/public/assets`

This PR reverts the default back to `public`