### PR TITLE
Make it configurable Site-wide basic authentication by nginx

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -54,6 +54,11 @@ server {
   client_max_body_size 4G;
   keepalive_timeout 10;
 
+<% if fetch(:nginx_auth_basic_user_file) %>
+  auth_basic "Restricted Area";
+  auth_basic_user_file <%= fetch(:nginx_auth_basic_user_file) %>;
+<% end %>
+
 <% if fetch(:app_server) && (fetch(:app_server_socket) || fetch(:app_server_port))%>
   location ^~ /assets/ {
     gzip_static on;


### PR DESCRIPTION
When deploying an web-app without basic auth feature, one may want to put basic-auth by nginx.

This PR enables site-wide nginx basic configuration.

Reference: http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html