### PR TITLE
Fix ssl deprecation warning

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -30,8 +30,7 @@ server {
 server {
 
 <% if fetch(:nginx_use_ssl) %>
-  listen 443;
-  ssl on;
+  listen 443 ssl;
   #ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_protocols TLSv1.2;
   ssl_ciphers HIGH:!aNULL:!MD5:!3DES;


### PR DESCRIPTION
solves warning of
    the “ssl” directive is deprecated, use the “listen … ssl”

refer: https://stackoverflow.com/q/51703109/3090068