### PR TITLE
nginx:configtest fix to sudo nginx -t

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ set :nginx_sites_available_dir, "/opt/nginx/sites-available"
 # default value: "#{fetch :application}"
 set :nginx_application_name, "#{fetch :application}-#{fetch :stage}"
 
-# Path where nginx available site are stored
+# Path where nginx enabled site are stored
 # default value: "/etc/nginx/sites-enabled"
 set :nginx_sites_enabled_dir, "/opt/nginx/sites-enabled"
 

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -23,12 +23,11 @@ namespace :nginx do
     end
   end
 
-  desc "Configtest nginx service"
+  desc "Configtest nginx"
   task :configtest do
     on release_roles fetch(:nginx_roles) do
-      nginx_service = fetch(:nginx_service_path)
       execute(
-          "sudo #{nginx_service} configtest",
+          "sudo nginx -t",
           interaction_handler: PasswdInteractionHandler.new
       )
     end


### PR DESCRIPTION
Under centos there is no ```sudo service nginx configtest``` but ```sudo nginx -t``` works the same under Ubuntu and centos